### PR TITLE
WIP: :sparkles: add hass-cli

### DIFF
--- a/ide/Dockerfile
+++ b/ide/Dockerfile
@@ -50,7 +50,7 @@ RUN \
         zsh-syntax-highlighting=0.6.0-r0 \
         zsh=5.5.1-r0 \
     \
-    && pip install yamllint==1.14.0 --no-cache-dir \
+    && pip install yamllint==1.14.0 homeassistant-cli==0.5.0 --no-cache-dir \
     \
     && yarn global add npm@4.6.1 modclean \
     \

--- a/ide/rootfs/root/.zshrc
+++ b/ide/rootfs/root/.zshrc
@@ -86,5 +86,8 @@ source /usr/share/zsh/plugins/zsh-syntax-highlighting/zsh-syntax-highlighting.zs
 # alias zshconfig="mate ~/.zshrc"
 # alias ohmyzsh="mate ~/.oh-my-zsh"
 
+# Home Assistant CLI
+eval "$(_HASS_CLI_COMPLETE=source_zsh hass-cli)"
+
 # Show motd on start
 cat /etc/motd


### PR DESCRIPTION
# Proposed Changes

Adds hass-cli in pip install step
setup auto completion for hass-cli like done in addon-ssh

> (Describe the changes and rationale behind them)

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

Fixes #35
 
[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/